### PR TITLE
Add configuration options: FixedXP, FixedXPRate

### DIFF
--- a/conf/SoloLfg.conf.dist
+++ b/conf/SoloLfg.conf.dist
@@ -23,11 +23,9 @@ SoloLFG.Announce = 1
 #        Description: Set the XP rate in dungeons to FixedXPRate
 #        Default:     1  - (Enabled)
 #                     0  - (Disabled)
-#
 
 SoloLFG.FixedXP = 1
 
-#
 #    SoloLFG.FixedXPRate
 #        Description: Set the fixed XP rate used in dungeons
 #        Default:     0.2 (The same XP gained in a full party of 5)

--- a/conf/SoloLfg.conf.dist
+++ b/conf/SoloLfg.conf.dist
@@ -20,11 +20,18 @@ SoloLFG.Enable = 1
 SoloLFG.Announce = 1
 
 #    SoloLFG.FixedXP
-#        Description: Set the XP rate in dungeons to 1.0
+#        Description: Set the XP rate in dungeons to FixedXPRate
 #        Default:     1  - (Enabled)
 #                     0  - (Disabled)
 #
 
 SoloLFG.FixedXP = 1
+
+#
+#    SoloLFG.FixedXPRate
+#        Description: Set the fixed XP rate used in dungeons
+#        Default:     0.2 (The same XP gained in a full party of 5)
+
+SoloLFG.FixedXPRate = 0.2
 
 ###################################################################################################

--- a/conf/SoloLfg.conf.dist
+++ b/conf/SoloLfg.conf.dist
@@ -19,4 +19,12 @@ SoloLFG.Enable = 1
 
 SoloLFG.Announce = 1
 
+#    SoloLFG.FixedXP
+#        Description: Set the XP rate in dungeons to 1.0
+#        Default:     1  - (Enabled)
+#                     0  - (Disabled)
+#
+
+SoloLFG.FixedXP = 1
+
 ###################################################################################################

--- a/src/Lfg_Solo.cpp
+++ b/src/Lfg_Solo.cpp
@@ -27,7 +27,7 @@ public:
         }
     }
 
-    void OnRewardKillRewarder(Player*, bool isDungeon, float& rate) override
+    void OnRewardKillRewarder(Player* /*player*/, bool isDungeon, float& rate) override
     {
         if (!isDungeon
             || !sConfigMgr->GetOption<bool>("SoloLFG.Enable", true)

--- a/src/Lfg_Solo.cpp
+++ b/src/Lfg_Solo.cpp
@@ -18,13 +18,26 @@ class lfg_solo_announce : public PlayerScript
 public:
     lfg_solo_announce() : PlayerScript("lfg_solo_announce") {}
 
-    void OnLogin(Player* player)
+    void OnLogin(Player* player) override
     {
         // Announce Module
         if (sConfigMgr->GetOption<bool>("SoloLFG.Announce", true))
         {
             ChatHandler(player->GetSession()).SendSysMessage("This server is running the |cff4CFF00Solo Dungeon Finder |rmodule.");
         }
+    }
+
+    void OnRewardKillRewarder(Player*, bool isDungeon, float& rate) override
+    {
+        if (!isDungeon
+            || !sConfigMgr->GetOption<bool>("SoloLFG.Enable", true)
+            || !sConfigMgr->GetOption<bool>("SoloLFG.FixedXP", true))
+        {
+            return;
+        }
+
+        // Force the rate to 1.0 regardless of group size, to encourage group play
+        rate = 1.0;
     }
 };
 

--- a/src/Lfg_Solo.cpp
+++ b/src/Lfg_Solo.cpp
@@ -27,7 +27,7 @@ public:
         }
     }
 
-    void OnRewardKillRewarder(Player* /*player*/, bool isDungeon, float& rate) override
+    void OnRewardKillRewarder(Player* /*player*/, KillRewarder* /*rewarder*/, bool isDungeon, float& rate) override
     {
         if (!isDungeon
             || !sConfigMgr->GetOption<bool>("SoloLFG.Enable", true)

--- a/src/Lfg_Solo.cpp
+++ b/src/Lfg_Solo.cpp
@@ -36,7 +36,7 @@ public:
             return;
         }
 
-        // Force the rate to 1.0 regardless of group size, to encourage group play
+        // Force the rate to FixedXPRate regardless of group size, to encourage group play
         rate = sConfigMgr->GetOption<float>("SoloLFG.FixedXPRate", 0.2);
     }
 };

--- a/src/Lfg_Solo.cpp
+++ b/src/Lfg_Solo.cpp
@@ -37,7 +37,7 @@ public:
         }
 
         // Force the rate to 1.0 regardless of group size, to encourage group play
-        rate = 1.0;
+        rate = sConfigMgr->GetOption<float>("SoloLFG.FixedXPRate", 0.2);
     }
 };
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Added options to fix the XP rate, overriding the scaling which would originally be based on number of players in the party
- Changes effective XP in a default configuration when soloing from 5x, to 1x

## Purpose:
<!-- If your fix has a relating issue, link it below -->
- Encourage group play, by removing any XP disincentive to having additional players
- Correct the XP rewarded players to be more proportionate with quests (hence 0.2 default instead of 1.0)

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
Not sure if applicable for enhancement change

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 1: Built, loaded onto dev server, compared XP gain when killing the same creature against unmodified prod server when XPRate is set to 1.0, observed same XP gain on both servers in solo play
- 2: On dev server, invited second player, observed no change in XP
- 3: Changed XP rate to from 1.0, observed XP gain is now 20% of what it was when set to 1.0


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Build, config, etc
2. Join the server and queue into a dungeon with varying number of players
3. Observe the same creature will give the same amount of XP, regardless of number of players in the party
